### PR TITLE
schema/country: Add a schema for a country

### DIFF
--- a/schema/country.schema.json
+++ b/schema/country.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "https://democratic.guide/country.schema.json",
+  "title": "Country Schema",
+  "description": "Schema describing a country",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Unique identifier for a country",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location of the country",
+      "type": "object",
+      "properties": {
+        "latitude": {
+          "description": "Latitude of the country",
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "description": "Longitude of the country",
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        }
+      },
+      "required": [
+        "latitude",
+        "longitude"
+      ]
+    },
+    "population": {
+      "description": "Population of the country",
+      "type": "number"
+    },
+    "population_year": {
+      "description": "Year at which the population was measured",
+      "type": "number"
+    },
+    "area": {
+      "description": "Area of the country, in km2",
+      "type": "number"
+    },
+    "currency": {
+      "description": "Currency of the country",
+      "type": "string"
+    },
+    "details": {
+      "description": "Details of the country in a given language",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "description": "Language of the description",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the country",
+            "type": "string"
+          },
+          "description": {
+            "description": "Name of the country",
+            "type": "string"
+          },
+          "capital": {
+            "description": "Capital of the country",
+            "type": "string"
+          },
+          
+          "languages": {
+            "description": "Languages spoken in the country",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "capital",
+          "languages"
+        ]
+      }
+    }
+  },
+  "required": [
+    "id",
+    "location",
+    "details",
+    "population",
+    "population_year",
+    "area",
+    "currency"
+  ]
+}


### PR DESCRIPTION
This is a very basic schema now, but is setting an initial foundation for adding more country information in the future.

The schema attempts to be as language independenent as possible, hence all the details are to be specified in a given language.