### PR TITLE
country/ireland: Add schema reference

### DIFF
--- a/country/ireland.json
+++ b/country/ireland.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://schema.democratic.guide/country.schema.json",
   "id": "ie",
   "location": {
     "latitude": 53.339428,


### PR DESCRIPTION
The schema reference will be used to validate that the country follows
the country schema.